### PR TITLE
fix: use expanded JSON-LD type when performing validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,24 +53,24 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.26.2",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
-			"integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.25.9",
+				"@babel/helper-validator-identifier": "^7.27.1",
 				"js-tokens": "^4.0.0",
-				"picocolors": "^1.0.0"
+				"picocolors": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.25.9.tgz",
-			"integrity": "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -78,9 +78,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.25.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
-			"integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+			"version": "7.27.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+			"integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -88,13 +88,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.0.tgz",
-			"integrity": "sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==",
+			"version": "7.27.3",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.3.tgz",
+			"integrity": "sha512-xyYxRj6+tLNDTWi0KCBcZ9V7yg3/lwL9DWh9Uwh/RIVlIfFidggcgxKX3GCXwCiswwcGRawBKbEg2LG/Y8eJhw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.27.0"
+				"@babel/types": "^7.27.3"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -104,14 +104,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.27.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.0.tgz",
-			"integrity": "sha512-H45s8fVLYjbhFH62dIJ3WtmJ6RSPt/3DRO0ZcT2SUiYiQyz3BLVb9ADEnLl91m74aQPS3AzzeajZHYOalWe3bg==",
+			"version": "7.27.3",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
+			"integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.25.9",
-				"@babel/helper-validator-identifier": "^7.25.9"
+				"@babel/helper-string-parser": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.27.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -164,13 +164,13 @@
 			}
 		},
 		"node_modules/@commitlint/config-validator": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.0.tgz",
-			"integrity": "sha512-+r5ZvD/0hQC3w5VOHJhGcCooiAVdynFlCe2d6I9dU+PvXdV3O+fU4vipVg+6hyLbQUuCH82mz3HnT/cBQTYYuA==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.8.1.tgz",
+			"integrity": "sha512-0jvJ4u+eqGPBIzzSdqKNX1rvdbSU1lPNYlfQQRIFnBgLy26BtC0cFnr7c/AyuzExMxWsMOte6MkTi9I3SQ3iGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^19.8.0",
+				"@commitlint/types": "^19.8.1",
 				"ajv": "^8.11.0"
 			},
 			"engines": {
@@ -178,13 +178,13 @@
 			}
 		},
 		"node_modules/@commitlint/ensure": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.0.tgz",
-			"integrity": "sha512-kNiNU4/bhEQ/wutI1tp1pVW1mQ0QbAjfPRo5v8SaxoVV+ARhkB8Wjg3BSseNYECPzWWfg/WDqQGIfV1RaBFQZg==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/ensure/-/ensure-19.8.1.tgz",
+			"integrity": "sha512-mXDnlJdvDzSObafjYrOSvZBwkD01cqB4gbnnFuVyNpGUM5ijwU/r/6uqUmBXAAOKRfyEjpkGVZxaDsCVnHAgyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^19.8.0",
+				"@commitlint/types": "^19.8.1",
 				"lodash.camelcase": "^4.3.0",
 				"lodash.kebabcase": "^4.1.1",
 				"lodash.snakecase": "^4.1.1",
@@ -196,9 +196,9 @@
 			}
 		},
 		"node_modules/@commitlint/execute-rule": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.0.tgz",
-			"integrity": "sha512-fuLeI+EZ9x2v/+TXKAjplBJWI9CNrHnyi5nvUQGQt4WRkww/d95oVRsc9ajpt4xFrFmqMZkd/xBQHZDvALIY7A==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.8.1.tgz",
+			"integrity": "sha512-YfJyIqIKWI64Mgvn/sE7FXvVMQER/Cd+s3hZke6cI1xgNT/f6ZAz5heND0QtffH+KbcqAwXDEE1/5niYayYaQA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -206,13 +206,13 @@
 			}
 		},
 		"node_modules/@commitlint/format": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.0.tgz",
-			"integrity": "sha512-EOpA8IERpQstxwp/WGnDArA7S+wlZDeTeKi98WMOvaDLKbjptuHWdOYYr790iO7kTCif/z971PKPI2PkWMfOxg==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/format/-/format-19.8.1.tgz",
+			"integrity": "sha512-kSJj34Rp10ItP+Eh9oCItiuN/HwGQMXBnIRk69jdOwEW9llW9FlyqcWYbHPSGofmjsqeoxa38UaEA5tsbm2JWw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^19.8.0",
+				"@commitlint/types": "^19.8.1",
 				"chalk": "^5.3.0"
 			},
 			"engines": {
@@ -220,13 +220,13 @@
 			}
 		},
 		"node_modules/@commitlint/is-ignored": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.0.tgz",
-			"integrity": "sha512-L2Jv9yUg/I+jF3zikOV0rdiHUul9X3a/oU5HIXhAJLE2+TXTnEBfqYP9G5yMw/Yb40SnR764g4fyDK6WR2xtpw==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/is-ignored/-/is-ignored-19.8.1.tgz",
+			"integrity": "sha512-AceOhEhekBUQ5dzrVhDDsbMaY5LqtN8s1mqSnT2Kz1ERvVZkNihrs3Sfk1Je/rxRNbXYFzKZSHaPsEJJDJV8dg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^19.8.0",
+				"@commitlint/types": "^19.8.1",
 				"semver": "^7.6.0"
 			},
 			"engines": {
@@ -234,32 +234,32 @@
 			}
 		},
 		"node_modules/@commitlint/lint": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.0.tgz",
-			"integrity": "sha512-+/NZKyWKSf39FeNpqhfMebmaLa1P90i1Nrb1SrA7oSU5GNN/lksA4z6+ZTnsft01YfhRZSYMbgGsARXvkr/VLQ==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/lint/-/lint-19.8.1.tgz",
+			"integrity": "sha512-52PFbsl+1EvMuokZXLRlOsdcLHf10isTPlWwoY1FQIidTsTvjKXVXYb7AvtpWkDzRO2ZsqIgPK7bI98x8LRUEw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/is-ignored": "^19.8.0",
-				"@commitlint/parse": "^19.8.0",
-				"@commitlint/rules": "^19.8.0",
-				"@commitlint/types": "^19.8.0"
+				"@commitlint/is-ignored": "^19.8.1",
+				"@commitlint/parse": "^19.8.1",
+				"@commitlint/rules": "^19.8.1",
+				"@commitlint/types": "^19.8.1"
 			},
 			"engines": {
 				"node": ">=v18"
 			}
 		},
 		"node_modules/@commitlint/load": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.0.tgz",
-			"integrity": "sha512-4rvmm3ff81Sfb+mcWT5WKlyOa+Hd33WSbirTVUer0wjS1Hv/Hzr07Uv1ULIV9DkimZKNyOwXn593c+h8lsDQPQ==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/load/-/load-19.8.1.tgz",
+			"integrity": "sha512-9V99EKG3u7z+FEoe4ikgq7YGRCSukAcvmKQuTtUyiYPnOd9a2/H9Ak1J9nJA1HChRQp9OA/sIKPugGS+FK/k1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/config-validator": "^19.8.0",
-				"@commitlint/execute-rule": "^19.8.0",
-				"@commitlint/resolve-extends": "^19.8.0",
-				"@commitlint/types": "^19.8.0",
+				"@commitlint/config-validator": "^19.8.1",
+				"@commitlint/execute-rule": "^19.8.1",
+				"@commitlint/resolve-extends": "^19.8.1",
+				"@commitlint/types": "^19.8.1",
 				"chalk": "^5.3.0",
 				"cosmiconfig": "^9.0.0",
 				"cosmiconfig-typescript-loader": "^6.1.0",
@@ -272,9 +272,9 @@
 			}
 		},
 		"node_modules/@commitlint/message": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.0.tgz",
-			"integrity": "sha512-qs/5Vi9bYjf+ZV40bvdCyBn5DvbuelhR6qewLE8Bh476F7KnNyLfdM/ETJ4cp96WgeeHo6tesA2TMXS0sh5X4A==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/message/-/message-19.8.1.tgz",
+			"integrity": "sha512-+PMLQvjRXiU+Ae0Wc+p99EoGEutzSXFVwQfa3jRNUZLNW5odZAyseb92OSBTKCu+9gGZiJASt76Cj3dLTtcTdg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -282,13 +282,13 @@
 			}
 		},
 		"node_modules/@commitlint/parse": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.0.tgz",
-			"integrity": "sha512-YNIKAc4EXvNeAvyeEnzgvm1VyAe0/b3Wax7pjJSwXuhqIQ1/t2hD3OYRXb6D5/GffIvaX82RbjD+nWtMZCLL7Q==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/parse/-/parse-19.8.1.tgz",
+			"integrity": "sha512-mmAHYcMBmAgJDKWdkjIGq50X4yB0pSGpxyOODwYmoexxxiUCy5JJT99t1+PEMK7KtsCtzuWYIAXYAiKR+k+/Jw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/types": "^19.8.0",
+				"@commitlint/types": "^19.8.1",
 				"conventional-changelog-angular": "^7.0.0",
 				"conventional-commits-parser": "^5.0.0"
 			},
@@ -297,31 +297,38 @@
 			}
 		},
 		"node_modules/@commitlint/read": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.0.tgz",
-			"integrity": "sha512-6ywxOGYajcxK1y1MfzrOnwsXO6nnErna88gRWEl3qqOOP8MDu/DTeRkGLXBFIZuRZ7mm5yyxU5BmeUvMpNte5w==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/read/-/read-19.8.1.tgz",
+			"integrity": "sha512-03Jbjb1MqluaVXKHKRuGhcKWtSgh3Jizqy2lJCRbRrnWpcM06MYm8th59Xcns8EqBYvo0Xqb+2DoZFlga97uXQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/top-level": "^19.8.0",
-				"@commitlint/types": "^19.8.0",
+				"@commitlint/top-level": "^19.8.1",
+				"@commitlint/types": "^19.8.1",
 				"git-raw-commits": "^4.0.0",
 				"minimist": "^1.2.8",
-				"tinyexec": "^0.3.0"
+				"tinyexec": "^1.0.0"
 			},
 			"engines": {
 				"node": ">=v18"
 			}
 		},
+		"node_modules/@commitlint/read/node_modules/tinyexec": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.1.tgz",
+			"integrity": "sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@commitlint/resolve-extends": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.0.tgz",
-			"integrity": "sha512-CLanRQwuG2LPfFVvrkTrBR/L/DMy3+ETsgBqW1OvRxmzp/bbVJW0Xw23LnnExgYcsaFtos967lul1CsbsnJlzQ==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.8.1.tgz",
+			"integrity": "sha512-GM0mAhFk49I+T/5UCYns5ayGStkTt4XFFrjjf0L4S26xoMTSkdCf9ZRO8en1kuopC4isDFuEm7ZOm/WRVeElVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/config-validator": "^19.8.0",
-				"@commitlint/types": "^19.8.0",
+				"@commitlint/config-validator": "^19.8.1",
+				"@commitlint/types": "^19.8.1",
 				"global-directory": "^4.0.1",
 				"import-meta-resolve": "^4.0.0",
 				"lodash.mergewith": "^4.6.2",
@@ -332,25 +339,25 @@
 			}
 		},
 		"node_modules/@commitlint/rules": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.0.tgz",
-			"integrity": "sha512-IZ5IE90h6DSWNuNK/cwjABLAKdy8tP8OgGVGbXe1noBEX5hSsu00uRlLu6JuruiXjWJz2dZc+YSw3H0UZyl/mA==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/rules/-/rules-19.8.1.tgz",
+			"integrity": "sha512-Hnlhd9DyvGiGwjfjfToMi1dsnw1EXKGJNLTcsuGORHz6SS9swRgkBsou33MQ2n51/boIDrbsg4tIBbRpEWK2kw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@commitlint/ensure": "^19.8.0",
-				"@commitlint/message": "^19.8.0",
-				"@commitlint/to-lines": "^19.8.0",
-				"@commitlint/types": "^19.8.0"
+				"@commitlint/ensure": "^19.8.1",
+				"@commitlint/message": "^19.8.1",
+				"@commitlint/to-lines": "^19.8.1",
+				"@commitlint/types": "^19.8.1"
 			},
 			"engines": {
 				"node": ">=v18"
 			}
 		},
 		"node_modules/@commitlint/to-lines": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.0.tgz",
-			"integrity": "sha512-3CKLUw41Cur8VMjh16y8LcsOaKbmQjAKCWlXx6B0vOUREplp6em9uIVhI8Cv934qiwkbi2+uv+mVZPnXJi1o9A==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/to-lines/-/to-lines-19.8.1.tgz",
+			"integrity": "sha512-98Mm5inzbWTKuZQr2aW4SReY6WUukdWXuZhrqf1QdKPZBCCsXuG87c+iP0bwtD6DBnmVVQjgp4whoHRVixyPBg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -358,9 +365,9 @@
 			}
 		},
 		"node_modules/@commitlint/top-level": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.0.tgz",
-			"integrity": "sha512-Rphgoc/omYZisoNkcfaBRPQr4myZEHhLPx2/vTXNLjiCw4RgfPR1wEgUpJ9OOmDCiv5ZyIExhprNLhteqH4FuQ==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/top-level/-/top-level-19.8.1.tgz",
+			"integrity": "sha512-Ph8IN1IOHPSDhURCSXBz44+CIu+60duFwRsg6HqaISFHQHbmBtxVw4ZrFNIYUzEP7WwrNPxa2/5qJ//NK1FGcw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -371,9 +378,9 @@
 			}
 		},
 		"node_modules/@commitlint/types": {
-			"version": "19.8.0",
-			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.0.tgz",
-			"integrity": "sha512-LRjP623jPyf3Poyfb0ohMj8I3ORyBDOwXAgxxVPbSD0unJuW2mJWeiRfaQinjtccMqC5Wy1HOMfa4btKjbNxbg==",
+			"version": "19.8.1",
+			"resolved": "https://registry.npmjs.org/@commitlint/types/-/types-19.8.1.tgz",
+			"integrity": "sha512-/yCrWGCoA1SVKOks25EGadP9Pnj0oAIHGpl2wH2M2Y46dPM2ueb8wyCVOD7O3WCTkaJ0IkKvzhl1JY7+uCT2Dw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -553,9 +560,9 @@
 			}
 		},
 		"node_modules/@cspell/dict-companies": {
-			"version": "3.1.15",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.1.15.tgz",
-			"integrity": "sha512-vnGYTJFrqM9HdtgpZFOThFTjlPyJWqPi0eidMKyZxMKTHhP7yg6mD5X9WPEPvfiysmJYMnA6KKYQEBqoKFPU9g==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-companies/-/dict-companies-3.2.1.tgz",
+			"integrity": "sha512-ryaeJ1KhTTKL4mtinMtKn8wxk6/tqD4vX5tFP+Hg89SiIXmbMk5vZZwVf+eyGUWJOyw5A1CVj9EIWecgoi+jYQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -609,9 +616,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-docker": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.13.tgz",
-			"integrity": "sha512-85X+ZC/CPT3ie26DcfeMFkZSNuhS8DlAqPXzAjilHtGE/Nj+QnS3jyBz0spDJOJrjh8wx1+ro2oCK98sbVcztw==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-docker/-/dict-docker-1.1.14.tgz",
+			"integrity": "sha512-p6Qz5mokvcosTpDlgSUREdSbZ10mBL3ndgCdEKMqjCSZJFdfxRdNdjrGER3lQ6LMq5jGr1r7nGXA0gvUJK80nw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -630,16 +637,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-en_us": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.2.tgz",
-			"integrity": "sha512-mvpv2kWayuOExCnDgvhlYDoW7gbGvGVTyuof9aFGy0+8ALYAJ2AtlvYCqzdTTKvvsYBrxAEEWFkUh75kHnHibg==",
+			"version": "4.4.9",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-en_us/-/dict-en_us-4.4.9.tgz",
+			"integrity": "sha512-5gjqpUwhE+qP9A9wxD1+MGGJ3DNqTgSpiOsS10cGJfV4p/Z194XkDUZrUrJsnJA/3fsCZHAzcNWh8m0bw1v++A==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-en-common-misspellings": {
-			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.10.tgz",
-			"integrity": "sha512-80mXJLtr0tVEtzowrI7ycVae/ULAYImZUlr0kUTpa8i57AUk7Zy3pYBs44EYIKW7ZC9AHu4Qjjfq4vriAtyTDQ==",
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-en-common-misspellings/-/dict-en-common-misspellings-2.0.11.tgz",
+			"integrity": "sha512-xFQjeg0wFHh9sFhshpJ+5BzWR1m9Vu8pD0CGPkwZLK9oii8AD8RXNchabLKy/O5VTLwyqPOi9qpyp1cxm3US4Q==",
 			"dev": true,
 			"license": "CC BY-SA 4.0"
 		},
@@ -651,9 +658,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-filetypes": {
-			"version": "3.0.11",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.11.tgz",
-			"integrity": "sha512-bBtCHZLo7MiSRUqx5KEiPdGOmXIlDGY+L7SJEtRWZENpAKE+96rT7hj+TUUYWBbCzheqHr0OXZJFEKDgsG/uZg==",
+			"version": "3.0.12",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-filetypes/-/dict-filetypes-3.0.12.tgz",
+			"integrity": "sha512-+ds5wgNdlUxuJvhg8A1TjuSpalDFGCh7SkANCWvIplg6QZPXL4j83lqxP7PgjHpx7PsBUS7vw0aiHPjZy9BItw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -693,16 +700,16 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-git": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.4.tgz",
-			"integrity": "sha512-C44M+m56rYn6QCsLbiKiedyPTMZxlDdEYAsPwwlL5bhMDDzXZ3Ic8OCQIhMbiunhCOJJT+er4URmOmM+sllnjg==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-git/-/dict-git-3.0.5.tgz",
+			"integrity": "sha512-I7l86J2nOcpBY0OcwXLTGMbcXbEE7nxZme9DmYKrNgmt35fcLu+WKaiXW7P29V+lIXjJo/wKrEDY+wUEwVuABQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-golang": {
-			"version": "6.0.20",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.20.tgz",
-			"integrity": "sha512-b7nd9XXs+apMMzNSWorjirQsbmlwcTC0ViQJU8u+XNose3z0y7oNeEpbTPTVoN1+1sO9aOHuFwfwoOMFCDS14Q==",
+			"version": "6.0.21",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-golang/-/dict-golang-6.0.21.tgz",
+			"integrity": "sha512-D3wG1MWhFx54ySFJ00CS1MVjR4UiBVsOWGIjJ5Av+HamnguqEshxbF9mvy+BX0KqzdLVzwFkoLBs8QeOID56HA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -818,9 +825,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-npm": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.0.tgz",
-			"integrity": "sha512-kTUdbSE8SuIMKMlASMbI8/SEwv3EmI8eBcwdrtu4PHA+XVx+8JvQCB5fcWK9mn/94Y7LQ1kDIm+yfAZfwopY0A==",
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-npm/-/dict-npm-5.2.4.tgz",
+			"integrity": "sha512-/hK5ii9OzSOQkmTjkzJlEYWz+PBnz2hRq5Xu7d4aDURaynO9xMAcK31JJlKNQulBkVbQHxFZLUrzjdzdAr/Opw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -846,9 +853,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-python": {
-			"version": "4.2.17",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.17.tgz",
-			"integrity": "sha512-xqMKfVc8d7yDaOChFdL2uWAN3Mw9qObB/Zr6t5w1OHbi23gWs7V1lI9d0mXAoqSK6N3mosbum4OIq/FleQDnlw==",
+			"version": "4.2.18",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-python/-/dict-python-4.2.18.tgz",
+			"integrity": "sha512-hYczHVqZBsck7DzO5LumBLJM119a3F17aj8a7lApnPIS7cmEwnPc2eACNscAHDk7qAo2127oI7axUoFMe9/g1g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -891,9 +898,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@cspell/dict-software-terms": {
-			"version": "5.0.5",
-			"resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.0.5.tgz",
-			"integrity": "sha512-ZjAOa8FI8/JrxaRqKT3eS7AQXFjU174xxQoKYMkmdwSyNIj7WUCAg10UeLqeMjFVv36zIO0Hm0dD2+Bvn18SLA==",
+			"version": "5.0.10",
+			"resolved": "https://registry.npmjs.org/@cspell/dict-software-terms/-/dict-software-terms-5.0.10.tgz",
+			"integrity": "sha512-2nTcVKTYJKU5GzeviXGPtRRC9d23MtfpD4PM4pLSzl29/5nx5MxOUHkzPuJdyaw9mXIz8Rm9IlGeVAvQoTI8aw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1013,9 +1020,9 @@
 			}
 		},
 		"node_modules/@esbuild/aix-ppc64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.2.tgz",
-			"integrity": "sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
+			"integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1030,9 +1037,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.2.tgz",
-			"integrity": "sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
+			"integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
 			"cpu": [
 				"arm"
 			],
@@ -1047,9 +1054,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.2.tgz",
-			"integrity": "sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
+			"integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1064,9 +1071,9 @@
 			}
 		},
 		"node_modules/@esbuild/android-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.2.tgz",
-			"integrity": "sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
+			"integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
 			"cpu": [
 				"x64"
 			],
@@ -1081,9 +1088,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.2.tgz",
-			"integrity": "sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
+			"integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -1098,9 +1105,9 @@
 			}
 		},
 		"node_modules/@esbuild/darwin-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.2.tgz",
-			"integrity": "sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
+			"integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1115,9 +1122,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.2.tgz",
-			"integrity": "sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
+			"integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1132,9 +1139,9 @@
 			}
 		},
 		"node_modules/@esbuild/freebsd-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.2.tgz",
-			"integrity": "sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
+			"integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
 			"cpu": [
 				"x64"
 			],
@@ -1149,9 +1156,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.2.tgz",
-			"integrity": "sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
+			"integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
 			"cpu": [
 				"arm"
 			],
@@ -1166,9 +1173,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.2.tgz",
-			"integrity": "sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
+			"integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
 			"cpu": [
 				"arm64"
 			],
@@ -1183,9 +1190,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ia32": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.2.tgz",
-			"integrity": "sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
+			"integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
 			"cpu": [
 				"ia32"
 			],
@@ -1200,9 +1207,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-loong64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.2.tgz",
-			"integrity": "sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
+			"integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
 			"cpu": [
 				"loong64"
 			],
@@ -1217,9 +1224,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-mips64el": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.2.tgz",
-			"integrity": "sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
+			"integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
 			"cpu": [
 				"mips64el"
 			],
@@ -1234,9 +1241,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-ppc64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.2.tgz",
-			"integrity": "sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
+			"integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
 			"cpu": [
 				"ppc64"
 			],
@@ -1251,9 +1258,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-riscv64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.2.tgz",
-			"integrity": "sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
+			"integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
 			"cpu": [
 				"riscv64"
 			],
@@ -1268,9 +1275,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-s390x": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.2.tgz",
-			"integrity": "sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
+			"integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
 			"cpu": [
 				"s390x"
 			],
@@ -1285,9 +1292,9 @@
 			}
 		},
 		"node_modules/@esbuild/linux-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.2.tgz",
-			"integrity": "sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
+			"integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
 			"cpu": [
 				"x64"
 			],
@@ -1302,9 +1309,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.2.tgz",
-			"integrity": "sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
+			"integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1319,9 +1326,9 @@
 			}
 		},
 		"node_modules/@esbuild/netbsd-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.2.tgz",
-			"integrity": "sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
+			"integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
 			"cpu": [
 				"x64"
 			],
@@ -1336,9 +1343,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.2.tgz",
-			"integrity": "sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
+			"integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1353,9 +1360,9 @@
 			}
 		},
 		"node_modules/@esbuild/openbsd-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.2.tgz",
-			"integrity": "sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
+			"integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
 			"cpu": [
 				"x64"
 			],
@@ -1370,9 +1377,9 @@
 			}
 		},
 		"node_modules/@esbuild/sunos-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.2.tgz",
-			"integrity": "sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
+			"integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
 			"cpu": [
 				"x64"
 			],
@@ -1387,9 +1394,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-arm64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.2.tgz",
-			"integrity": "sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
+			"integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
 			"cpu": [
 				"arm64"
 			],
@@ -1404,9 +1411,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-ia32": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.2.tgz",
-			"integrity": "sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
+			"integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
 			"cpu": [
 				"ia32"
 			],
@@ -1421,9 +1428,9 @@
 			}
 		},
 		"node_modules/@esbuild/win32-x64": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.2.tgz",
-			"integrity": "sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
+			"integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
 			"cpu": [
 				"x64"
 			],
@@ -1438,9 +1445,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.6.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.6.1.tgz",
-			"integrity": "sha512-KTsJMmobmbrFLe3LDh0PC2FXpcSYJt/MLjlkh/9LEnmKYLSYmT/0EW9JWANjeoemiuZrmogti0tW5Ch+qNUYDw==",
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
+			"integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1609,16 +1616,16 @@
 			}
 		},
 		"node_modules/@gerrit0/mini-shiki": {
-			"version": "3.2.3",
-			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.2.3.tgz",
-			"integrity": "sha512-yemSYr0Oiqk5NAQRfbD5DKUTlThiZw1MxTMx/YpQTg6m4QRJDtV2JTYSuNevgx1ayy/O7x+uwDjh3IgECGFY/Q==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@gerrit0/mini-shiki/-/mini-shiki-3.4.2.tgz",
+			"integrity": "sha512-3jXo5bNjvvimvdbIhKGfFxSnKCX+MA8wzHv55ptzk/cx8wOzT+BRcYgj8aFN3yTiTs+zvQQiaZFr7Jce1ZG3fw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/engine-oniguruma": "^3.2.2",
-				"@shikijs/langs": "^3.2.2",
-				"@shikijs/themes": "^3.2.2",
-				"@shikijs/types": "^3.2.2",
+				"@shikijs/engine-oniguruma": "^3.4.2",
+				"@shikijs/langs": "^3.4.2",
+				"@shikijs/themes": "^3.4.2",
+				"@shikijs/types": "^3.4.2",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			}
 		},
@@ -2504,40 +2511,40 @@
 			}
 		},
 		"node_modules/@shikijs/engine-oniguruma": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.2.2.tgz",
-			"integrity": "sha512-vyXRnWVCSvokwbaUD/8uPn6Gqsf5Hv7XwcW4AgiU4Z2qwy19sdr6VGzMdheKKN58tJOOe5MIKiNb901bgcUXYQ==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-3.4.2.tgz",
+			"integrity": "sha512-zcZKMnNndgRa3ORja6Iemsr3DrLtkX3cAF7lTJkdMB6v9alhlBsX9uNiCpqofNrXOvpA3h6lHcLJxgCIhVOU5Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.2.2",
+				"@shikijs/types": "3.4.2",
 				"@shikijs/vscode-textmate": "^10.0.2"
 			}
 		},
 		"node_modules/@shikijs/langs": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.2.2.tgz",
-			"integrity": "sha512-NY0Urg2dV9ETt3JIOWoMPuoDNwte3geLZ4M1nrPHbkDS8dWMpKcEwlqiEIGqtwZNmt5gKyWpR26ln2Bg2ecPgw==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-3.4.2.tgz",
+			"integrity": "sha512-H6azIAM+OXD98yztIfs/KH5H4PU39t+SREhmM8LaNXyUrqj2mx+zVkr8MWYqjceSjDw9I1jawm1WdFqU806rMA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.2.2"
+				"@shikijs/types": "3.4.2"
 			}
 		},
 		"node_modules/@shikijs/themes": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.2.2.tgz",
-			"integrity": "sha512-Zuq4lgAxVKkb0FFdhHSdDkALuRpsj1so1JdihjKNQfgM78EHxV2JhO10qPsMrm01FkE3mDRTdF68wfmsqjt6HA==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-3.4.2.tgz",
+			"integrity": "sha512-qAEuAQh+brd8Jyej2UDDf+b4V2g1Rm8aBIdvt32XhDPrHvDkEnpb7Kzc9hSuHUxz0Iuflmq7elaDuQAP9bHIhg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@shikijs/types": "3.2.2"
+				"@shikijs/types": "3.4.2"
 			}
 		},
 		"node_modules/@shikijs/types": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.2.2.tgz",
-			"integrity": "sha512-a5TiHk7EH5Lso8sHcLHbVNNhWKP0Wi3yVnXnu73g86n3WoDgEra7n3KszyeCGuyoagspQ2fzvy4cpSc8pKhb0A==",
+			"version": "3.4.2",
+			"resolved": "https://registry.npmjs.org/@shikijs/types/-/types-3.4.2.tgz",
+			"integrity": "sha512-zHC1l7L+eQlDXLnxvM9R91Efh2V4+rN3oMVS2swCBssbj2U/FBwybD1eeLaq8yl/iwT+zih8iUbTBCgGZOYlVg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2553,14 +2560,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@twin.org/cli-core": {
-			"version": "0.0.1-next.52",
-			"resolved": "https://registry.npmjs.org/@twin.org/cli-core/-/cli-core-0.0.1-next.52.tgz",
-			"integrity": "sha512-x/TDv0TloVfrgpPLAEza1AbJv5NdHAUuGchK6pZ97eg+tDWGpwaoVH7fOJQGbgrlPHly50wumEEywTdF0XBlXw==",
+			"version": "0.0.1-next.56",
+			"resolved": "https://registry.npmjs.org/@twin.org/cli-core/-/cli-core-0.0.1-next.56.tgz",
+			"integrity": "sha512-WblHloRFKcZExkRL31399aAqZvWK9O11tWZq8c1aBUdSTMogXpYBJI6Cp1uqn4KtSB454iRdsgAOOKLWkbhPZg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "0.0.1-next.52",
-				"@twin.org/crypto": "0.0.1-next.52",
+				"@twin.org/core": "0.0.1-next.56",
+				"@twin.org/crypto": "0.0.1-next.56",
 				"@twin.org/nameof": "next",
 				"chalk": "5.4.1",
 				"commander": "13.1.0",
@@ -2571,9 +2578,9 @@
 			}
 		},
 		"node_modules/@twin.org/core": {
-			"version": "0.0.1-next.52",
-			"resolved": "https://registry.npmjs.org/@twin.org/core/-/core-0.0.1-next.52.tgz",
-			"integrity": "sha512-4v4xWSHATvogyOG8Cp5Emq7miN6wvoweVLAPDqeUf07qzFKmS5c3ltjYYJRTXJUXWb53luDN1tMZhQA5T/CWIQ==",
+			"version": "0.0.1-next.56",
+			"resolved": "https://registry.npmjs.org/@twin.org/core/-/core-0.0.1-next.56.tgz",
+			"integrity": "sha512-Vz5fU/we2uvyfDKbssDCkQoL2TNMSpQgZX8GeqVU1hnErlh4rXfwqAH8zTf/TXa8bRFbirp4SHDMU4ONqIo0uw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@twin.org/nameof": "next",
@@ -2585,9 +2592,9 @@
 			}
 		},
 		"node_modules/@twin.org/crypto": {
-			"version": "0.0.1-next.52",
-			"resolved": "https://registry.npmjs.org/@twin.org/crypto/-/crypto-0.0.1-next.52.tgz",
-			"integrity": "sha512-/dXmtZO7nQkbOW7QtAatyDZJJ8ym6DGEN1rwAeZG94rLTE04c+3MYWNEIqITc/n4G7STn5p7hbKZqwesQOjN9Q==",
+			"version": "0.0.1-next.56",
+			"resolved": "https://registry.npmjs.org/@twin.org/crypto/-/crypto-0.0.1-next.56.tgz",
+			"integrity": "sha512-Mrdedbngr/1Rl4e7bUsUtGgTBezH7J4HwTeVG+zoA/zlDWF1rmZyBklf94LTm87KzAPB9bnNfEZaBNtWOlAV4A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@noble/ciphers": "1.2.1",
@@ -2596,7 +2603,7 @@
 				"@scure/base": "1.2.4",
 				"@scure/bip32": "1.6.2",
 				"@scure/bip39": "1.5.4",
-				"@twin.org/core": "0.0.1-next.52",
+				"@twin.org/core": "0.0.1-next.56",
 				"@twin.org/nameof": "next",
 				"micro-key-producer": "0.7.5"
 			},
@@ -2617,12 +2624,12 @@
 			"link": true
 		},
 		"node_modules/@twin.org/entity": {
-			"version": "0.0.1-next.52",
-			"resolved": "https://registry.npmjs.org/@twin.org/entity/-/entity-0.0.1-next.52.tgz",
-			"integrity": "sha512-bI2WohrMK7o+rU0Vjq56E9WGFxDB3WRFb9w/4krUNnbp6uUtuE+oe6s8lCJoTPvBNJWDRf18wvxuHtIyzsml8A==",
+			"version": "0.0.1-next.56",
+			"resolved": "https://registry.npmjs.org/@twin.org/entity/-/entity-0.0.1-next.56.tgz",
+			"integrity": "sha512-0xG6p7ggLFzyQUnLUDNStA8yosvPXhhOm1fvW+K/RVlREeg6v64h1Uwlb/nOgIuKaq3VKycygxvC9lSJ6RPS0g==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "0.0.1-next.52",
+				"@twin.org/core": "0.0.1-next.56",
 				"@twin.org/nameof": "next",
 				"reflect-metadata": "0.2.2"
 			},
@@ -2712,9 +2719,9 @@
 			}
 		},
 		"node_modules/@twin.org/ts-to-schema/node_modules/jackspeak": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
-			"integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -2771,13 +2778,13 @@
 			}
 		},
 		"node_modules/@twin.org/web": {
-			"version": "0.0.1-next.52",
-			"resolved": "https://registry.npmjs.org/@twin.org/web/-/web-0.0.1-next.52.tgz",
-			"integrity": "sha512-70TdPcI9Mnb3iUmfr49dXdoPyfpVv0u59nbdGmmveEQ3zwQQFlQ5yksJL+h02PISee3itoGjb6G+/H2Hw6y9Fw==",
+			"version": "0.0.1-next.56",
+			"resolved": "https://registry.npmjs.org/@twin.org/web/-/web-0.0.1-next.56.tgz",
+			"integrity": "sha512-VzunUoCqTdQvnD1+fzfYH6Bx5HPpB+yYTmjMaIjKa1WTB3DA4H89xABCYWnMtMSx14DkCm1hPRHx0EV5pVq7ww==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@twin.org/core": "0.0.1-next.52",
-				"@twin.org/crypto": "0.0.1-next.52",
+				"@twin.org/core": "0.0.1-next.56",
+				"@twin.org/crypto": "0.0.1-next.56",
 				"@twin.org/nameof": "next",
 				"jose": "6.0.10"
 			},
@@ -2863,9 +2870,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/node": {
-			"version": "22.14.1",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.14.1.tgz",
-			"integrity": "sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==",
+			"version": "22.15.21",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.21.tgz",
+			"integrity": "sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3371,9 +3378,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
-			"integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.4.tgz",
+			"integrity": "sha512-cqv9H9GvAEoTaoq+cYqUTCGscUjKqlJZC7PRwY5FMySVj5J+xOm1KQcCiYHJOEzOKRUhLH4R2pTwvFlWCEScsg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3412,6 +3419,19 @@
 				"url": "https://opencollective.com/vitest"
 			}
 		},
+		"node_modules/@vitest/snapshot/node_modules/@vitest/pretty-format": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+			"integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
 		"node_modules/@vitest/spy": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.1.1.tgz",
@@ -3434,6 +3454,19 @@
 			"dependencies": {
 				"@vitest/pretty-format": "3.1.1",
 				"loupe": "^3.1.3",
+				"tinyrainbow": "^2.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/vitest"
+			}
+		},
+		"node_modules/@vitest/utils/node_modules/@vitest/pretty-format": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.1.1.tgz",
+			"integrity": "sha512-dg0CIzNx+hMMYfNmSqJlLSXEmnNhMswcn3sXO7Tpldr0LiGmg3eXdLLhwkv2ZqgHb/d5xg5F7ezNFRA1fA13yA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
 				"tinyrainbow": "^2.0.0"
 			},
 			"funding": {
@@ -3840,9 +3873,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.24.4",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
-			"integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
+			"version": "4.24.5",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.5.tgz",
+			"integrity": "sha512-FDToo4Wo82hIdgc1CQ+NQD0hEhmpPjrZ3hiUgwgOG6IuTdlpr8jdjyG24P6cNP1yJpTLzS5OcGgSw0xmDU1/Tw==",
 			"dev": true,
 			"funding": [
 				{
@@ -3860,10 +3893,10 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001688",
-				"electron-to-chromium": "^1.5.73",
+				"caniuse-lite": "^1.0.30001716",
+				"electron-to-chromium": "^1.5.149",
 				"node-releases": "^2.0.19",
-				"update-browserslist-db": "^1.1.1"
+				"update-browserslist-db": "^1.1.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -3984,9 +4017,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001714",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001714.tgz",
-			"integrity": "sha512-mtgapdwDLSSBnCI3JokHM7oEQBLxiJKVRtg10AxM1AyeiKcM96f0Mkbqeq+1AbiCtvMcHRulAAEMu693JrSWqg==",
+			"version": "1.0.30001718",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001718.tgz",
+			"integrity": "sha512-AflseV1ahcSunK53NfEs9gFWgOEmzr0f+kaMFA4xiLZlr9Hzt7HxcSpIFcnNCUkz6R6dWKa54rUz3HUmI3nVcw==",
 			"dev": true,
 			"funding": [
 				{
@@ -4850,9 +4883,9 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.41.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.41.0.tgz",
-			"integrity": "sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A==",
+			"version": "3.42.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.42.0.tgz",
+			"integrity": "sha512-bQasjMfyDGyaeWKBIu33lHh9qlSR0MFE/Nmc6nMjf/iU9b3rSMdAYz1Baxrv4lPdGUsTqZudHA4jIGSJy0SWZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5242,9 +5275,9 @@
 			}
 		},
 		"node_modules/debug": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-			"integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+			"integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5564,9 +5597,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.137",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.137.tgz",
-			"integrity": "sha512-/QSJaU2JyIuTbbABAo/crOs+SuAZLS+fVVS10PVrIT9hrRkmZl8Hb0xPSkKRUUWHQtYzXHpQUW3Dy5hwMzGZkA==",
+			"version": "1.5.158",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.158.tgz",
+			"integrity": "sha512-9vcp2xHhkvraY6AHw2WMi+GDSLPX42qe2xjYaVoZqFRJiOcilVQFq9mZmpuHEQpzlgGDelKlV7ZiGcmMsc8WxQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -5611,9 +5644,9 @@
 			}
 		},
 		"node_modules/es-abstract": {
-			"version": "1.23.9",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.9.tgz",
-			"integrity": "sha512-py07lI0wjxAC/DcfK1S6G7iANonniZwTISvdPzk9hzeH0IZIshbuuFxLIU96OyF89Yb9hiqWn8M/bY83KY5vzA==",
+			"version": "1.23.10",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.23.10.tgz",
+			"integrity": "sha512-MtUbM072wlJNyeYAe0mhzrD+M6DIJa96CZAOBBrhDbgKnB4MApIKefcyAB1eOdYn8cUNZgvwBvEzdoAYsxgEIw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -5621,18 +5654,18 @@
 				"arraybuffer.prototype.slice": "^1.0.4",
 				"available-typed-arrays": "^1.0.7",
 				"call-bind": "^1.0.8",
-				"call-bound": "^1.0.3",
+				"call-bound": "^1.0.4",
 				"data-view-buffer": "^1.0.2",
 				"data-view-byte-length": "^1.0.2",
 				"data-view-byte-offset": "^1.0.1",
 				"es-define-property": "^1.0.1",
 				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.0.0",
+				"es-object-atoms": "^1.1.1",
 				"es-set-tostringtag": "^2.1.0",
 				"es-to-primitive": "^1.3.0",
 				"function.prototype.name": "^1.1.8",
-				"get-intrinsic": "^1.2.7",
-				"get-proto": "^1.0.0",
+				"get-intrinsic": "^1.3.0",
+				"get-proto": "^1.0.1",
 				"get-symbol-description": "^1.1.0",
 				"globalthis": "^1.0.4",
 				"gopd": "^1.2.0",
@@ -5648,13 +5681,13 @@
 				"is-shared-array-buffer": "^1.0.4",
 				"is-string": "^1.1.1",
 				"is-typed-array": "^1.1.15",
-				"is-weakref": "^1.1.0",
+				"is-weakref": "^1.1.1",
 				"math-intrinsics": "^1.1.0",
-				"object-inspect": "^1.13.3",
+				"object-inspect": "^1.13.4",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.7",
 				"own-keys": "^1.0.1",
-				"regexp.prototype.flags": "^1.5.3",
+				"regexp.prototype.flags": "^1.5.4",
 				"safe-array-concat": "^1.1.3",
 				"safe-push-apply": "^1.0.0",
 				"safe-regex-test": "^1.1.0",
@@ -5667,7 +5700,7 @@
 				"typed-array-byte-offset": "^1.0.4",
 				"typed-array-length": "^1.0.7",
 				"unbox-primitive": "^1.1.0",
-				"which-typed-array": "^1.1.18"
+				"which-typed-array": "^1.1.19"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -5697,9 +5730,9 @@
 			}
 		},
 		"node_modules/es-module-lexer": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
-			"integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+			"integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5764,9 +5797,9 @@
 			}
 		},
 		"node_modules/esbuild": {
-			"version": "0.25.2",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.2.tgz",
-			"integrity": "sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==",
+			"version": "0.25.5",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
+			"integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -5777,31 +5810,31 @@
 				"node": ">=18"
 			},
 			"optionalDependencies": {
-				"@esbuild/aix-ppc64": "0.25.2",
-				"@esbuild/android-arm": "0.25.2",
-				"@esbuild/android-arm64": "0.25.2",
-				"@esbuild/android-x64": "0.25.2",
-				"@esbuild/darwin-arm64": "0.25.2",
-				"@esbuild/darwin-x64": "0.25.2",
-				"@esbuild/freebsd-arm64": "0.25.2",
-				"@esbuild/freebsd-x64": "0.25.2",
-				"@esbuild/linux-arm": "0.25.2",
-				"@esbuild/linux-arm64": "0.25.2",
-				"@esbuild/linux-ia32": "0.25.2",
-				"@esbuild/linux-loong64": "0.25.2",
-				"@esbuild/linux-mips64el": "0.25.2",
-				"@esbuild/linux-ppc64": "0.25.2",
-				"@esbuild/linux-riscv64": "0.25.2",
-				"@esbuild/linux-s390x": "0.25.2",
-				"@esbuild/linux-x64": "0.25.2",
-				"@esbuild/netbsd-arm64": "0.25.2",
-				"@esbuild/netbsd-x64": "0.25.2",
-				"@esbuild/openbsd-arm64": "0.25.2",
-				"@esbuild/openbsd-x64": "0.25.2",
-				"@esbuild/sunos-x64": "0.25.2",
-				"@esbuild/win32-arm64": "0.25.2",
-				"@esbuild/win32-ia32": "0.25.2",
-				"@esbuild/win32-x64": "0.25.2"
+				"@esbuild/aix-ppc64": "0.25.5",
+				"@esbuild/android-arm": "0.25.5",
+				"@esbuild/android-arm64": "0.25.5",
+				"@esbuild/android-x64": "0.25.5",
+				"@esbuild/darwin-arm64": "0.25.5",
+				"@esbuild/darwin-x64": "0.25.5",
+				"@esbuild/freebsd-arm64": "0.25.5",
+				"@esbuild/freebsd-x64": "0.25.5",
+				"@esbuild/linux-arm": "0.25.5",
+				"@esbuild/linux-arm64": "0.25.5",
+				"@esbuild/linux-ia32": "0.25.5",
+				"@esbuild/linux-loong64": "0.25.5",
+				"@esbuild/linux-mips64el": "0.25.5",
+				"@esbuild/linux-ppc64": "0.25.5",
+				"@esbuild/linux-riscv64": "0.25.5",
+				"@esbuild/linux-s390x": "0.25.5",
+				"@esbuild/linux-x64": "0.25.5",
+				"@esbuild/netbsd-arm64": "0.25.5",
+				"@esbuild/netbsd-x64": "0.25.5",
+				"@esbuild/openbsd-arm64": "0.25.5",
+				"@esbuild/openbsd-x64": "0.25.5",
+				"@esbuild/sunos-x64": "0.25.5",
+				"@esbuild/win32-arm64": "0.25.5",
+				"@esbuild/win32-ia32": "0.25.5",
+				"@esbuild/win32-x64": "0.25.5"
 			}
 		},
 		"node_modules/escalade": {
@@ -6150,14 +6183,13 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier/node_modules/synckit": {
-			"version": "0.11.4",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.4.tgz",
-			"integrity": "sha512-Q/XQKRaJiLiFIBNN+mndW7S/RHxvwzuZS6ZwmRzUBqJBv/5QIKCEwkBC8GBf8EQJKYnaFs0wOZbKTXBPj8L9oQ==",
+			"version": "0.11.6",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.6.tgz",
+			"integrity": "sha512-2pR2ubZSV64f/vqm9eLPz/KOvR9Dm+Co/5ChLgeHl0yEDRc6h5hXHoxEQH8Y5Ljycozd3p1k5TTSVdzYGkPvLw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@pkgr/core": "^0.2.3",
-				"tslib": "^2.8.1"
+				"@pkgr/core": "^0.2.4"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -8710,9 +8742,9 @@
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/ignore": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
-			"integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
+			"version": "7.0.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
+			"integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8776,13 +8808,22 @@
 			}
 		},
 		"node_modules/micro-packed": {
-			"version": "0.7.2",
-			"resolved": "https://registry.npmjs.org/micro-packed/-/micro-packed-0.7.2.tgz",
-			"integrity": "sha512-HJ/u8+tMzgrJVAl6P/4l8KGjJSA3SCZaRb1m4wpbovNScCSmVOGUYbkkcoPPcknCHWPpRAdjy+yqXqyQWf+k8g==",
+			"version": "0.7.3",
+			"resolved": "https://registry.npmjs.org/micro-packed/-/micro-packed-0.7.3.tgz",
+			"integrity": "sha512-2Milxs+WNC00TRlem41oRswvw31146GiSaoCT7s3Xi2gMUglW5QBeqlQaZeHr5tJx9nm3i57LNXPqxOOaWtTYg==",
 			"license": "MIT",
 			"dependencies": {
-				"@scure/base": "~1.2.2"
+				"@scure/base": "~1.2.5"
 			},
+			"funding": {
+				"url": "https://paulmillr.com/funding/"
+			}
+		},
+		"node_modules/micro-packed/node_modules/@scure/base": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.5.tgz",
+			"integrity": "sha512-9rE6EOVeIQzt5TSu4v+K523F8u6DhBsoZWPGKlnCshhlDhy0kJzUX4V+tr2dWmzF1GdekvThABoEQBGBQI7xZw==",
+			"license": "MIT",
 			"funding": {
 				"url": "https://paulmillr.com/funding/"
 			}
@@ -9465,6 +9506,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
 			"integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+			"deprecated": "Use your platform's native DOMException instead",
 			"funding": [
 				{
 					"type": "github",
@@ -10858,9 +10900,9 @@
 			}
 		},
 		"node_modules/semver": {
-			"version": "7.7.1",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
-			"integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+			"version": "7.7.2",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+			"integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -11075,9 +11117,9 @@
 			"license": "ISC"
 		},
 		"node_modules/smol-toml": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.3.tgz",
-			"integrity": "sha512-KMVLNWu490KlNfD0lbfDBUktJIEaZRBj1eeK0SMfdpO/rfyARIzlnPVI1Ge4l0vtSJmQUAiGKxMyLGrCT38iyA==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.3.4.tgz",
+			"integrity": "sha512-UOPtVuYkzYGee0Bd2Szz8d2G3RfMfJ2t3qVdZUAozZyAk+a0Sxa+QKix0YCwjL/A1RR0ar44nCxaoN9FxdJGwA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -11534,13 +11576,13 @@
 			"license": "MIT"
 		},
 		"node_modules/tinyglobby": {
-			"version": "0.2.12",
-			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.12.tgz",
-			"integrity": "sha512-qkf4trmKSIiMTs/E63cxH+ojC2unam7rJ0WrauAzpT3ECNTxGRMlaXxVbfxMUC/w0LaYk6jQ4y/nGR9uBO3tww==",
+			"version": "0.2.14",
+			"resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
+			"integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fdir": "^6.4.3",
+				"fdir": "^6.4.4",
 				"picomatch": "^4.0.2"
 			},
 			"engines": {
@@ -11551,9 +11593,9 @@
 			}
 		},
 		"node_modules/tinyglobby/node_modules/fdir": {
-			"version": "6.4.3",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-			"integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+			"version": "6.4.4",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+			"integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -11678,9 +11720,9 @@
 			}
 		},
 		"node_modules/ts-json-schema-generator/node_modules/glob": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
-			"integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+			"integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -11702,9 +11744,9 @@
 			}
 		},
 		"node_modules/ts-json-schema-generator/node_modules/jackspeak": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
-			"integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -12208,18 +12250,18 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "6.3.1",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.1.tgz",
-			"integrity": "sha512-kkzzkqtMESYklo96HKKPE5KKLkC1amlsqt+RjFMlX2AvbRB/0wghap19NdBxxwGZ+h/C6DLCrcEphPIItlGrRQ==",
+			"version": "6.3.5",
+			"resolved": "https://registry.npmjs.org/vite/-/vite-6.3.5.tgz",
+			"integrity": "sha512-cZn6NDFE7wdTpINgs++ZJ4N49W2vRp8LCKrn3Ob1kYNtOo21vfDoaV5GzBfLU4MovSAB8uNRm4jgzVQZ+mBzPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.25.0",
-				"fdir": "^6.4.3",
+				"fdir": "^6.4.4",
 				"picomatch": "^4.0.2",
 				"postcss": "^8.5.3",
 				"rollup": "^4.34.9",
-				"tinyglobby": "^0.2.12"
+				"tinyglobby": "^0.2.13"
 			},
 			"bin": {
 				"vite": "bin/vite.js"
@@ -12306,9 +12348,9 @@
 			}
 		},
 		"node_modules/vite/node_modules/fdir": {
-			"version": "6.4.3",
-			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.3.tgz",
-			"integrity": "sha512-PMXmW2y1hDDfTSRc9gaXIuCCRpuoz3Kaz8cUelp3smouvfT632ozg2vrT6lJsHKKOF59YLbOGfAWGUcKEfRMQw==",
+			"version": "6.4.4",
+			"resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.4.tgz",
+			"integrity": "sha512-1NZP+GK4GfuAv3PqKvxQRDMjdSRZjnkq7KfhlNrCNNlZ0ygQFpebfrnfnq/W7fpUnAv9aGWmY1zKx7FYL3gwhg==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -12726,16 +12768,16 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "2.7.1",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
-			"integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+			"integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
 				"yaml": "bin.mjs"
 			},
 			"engines": {
-				"node": ">= 14"
+				"node": ">= 14.6"
 			}
 		},
 		"node_modules/yargs": {
@@ -12834,9 +12876,9 @@
 			}
 		},
 		"packages/data-core/node_modules/glob": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
-			"integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+			"integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -12858,9 +12900,9 @@
 			}
 		},
 		"packages/data-core/node_modules/jackspeak": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
-			"integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -12968,9 +13010,9 @@
 			}
 		},
 		"packages/data-framework/node_modules/glob": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
-			"integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+			"integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -12992,9 +13034,9 @@
 			}
 		},
 		"packages/data-framework/node_modules/jackspeak": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
-			"integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -13105,9 +13147,9 @@
 			}
 		},
 		"packages/data-json-ld/node_modules/glob": {
-			"version": "11.0.1",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.1.tgz",
-			"integrity": "sha512-zrQDm8XPnYEKawJScsnM0QzobJxlT/kHOOlRTio8IH/GrmxRE5fjllkzdaHclIuNjUQTJYH2xHNIGfdpJkDJUw==",
+			"version": "11.0.2",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.2.tgz",
+			"integrity": "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -13129,9 +13171,9 @@
 			}
 		},
 		"packages/data-json-ld/node_modules/jackspeak": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.0.tgz",
-			"integrity": "sha512-9DDdhb5j6cpeitCbvLO7n7J4IxnbM6hoF6O1g4HQ5TfhvvKN8ywDM7668ZhMHRqVmxqhps/F6syWK2KcPxYlkw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
+			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {

--- a/packages/data-core/docs/reference/classes/DataTypeHelper.md
+++ b/packages/data-core/docs/reference/classes/DataTypeHelper.md
@@ -14,6 +14,58 @@ Class to help with data types.
 
 ## Methods
 
+### validateWithExpandedType()
+
+> `static` **validateWithExpandedType**(`propertyName`, `dataType`, `expandedDataType`, `data`, `validationFailures`, `validationMode?`): `Promise`\<`boolean`\>
+
+Validate a data type.
+
+#### Parameters
+
+##### propertyName
+
+`string`
+
+The name of the property being validated to use in error messages.
+
+##### dataType
+
+The data type to validate.
+
+`undefined` | `string`
+
+##### expandedDataType
+
+The Fully Qualified Name of the Data Type to validate.
+
+`undefined` | `string`
+
+##### data
+
+`unknown`
+
+The data to validate.
+
+##### validationFailures
+
+`IValidationFailure`[]
+
+The list of validation failures to add to.
+
+##### validationMode?
+
+[`ValidationMode`](../type-aliases/ValidationMode.md)
+
+The validation mode to use, defaults to either.
+
+#### Returns
+
+`Promise`\<`boolean`\>
+
+True if the data was valid.
+
+***
+
 ### validate()
 
 > `static` **validate**(`propertyName`, `dataType`, `data`, `validationFailures`, `validationMode?`): `Promise`\<`boolean`\>

--- a/packages/data-core/src/utils/dataTypeHelper.ts
+++ b/packages/data-core/src/utils/dataTypeHelper.ts
@@ -14,6 +14,70 @@ export class DataTypeHelper {
 	 * Validate a data type.
 	 * @param propertyName The name of the property being validated to use in error messages.
 	 * @param dataType The data type to validate.
+	 * @param expandedDataType The Fully Qualified Name of the Data Type to validate.
+	 * @param data The data to validate.
+	 * @param validationFailures The list of validation failures to add to.
+	 * @param validationMode The validation mode to use, defaults to either.
+	 * @returns True if the data was valid.
+	 */
+	public static async validateWithExpandedType(
+		propertyName: string,
+		dataType: string | undefined,
+		expandedDataType: string | undefined,
+		data: unknown,
+		validationFailures: IValidationFailure[],
+		validationMode?: ValidationMode
+	): Promise<boolean> {
+		let handler;
+		if (Is.stringValue(expandedDataType)) {
+			handler = DataTypeHandlerFactory.getIfExists(expandedDataType);
+		} else if (Is.stringValue(dataType)) {
+			handler = DataTypeHandlerFactory.getIfExists(dataType);
+		}
+
+		if (handler) {
+			validationMode = validationMode ?? ValidationMode.Either;
+
+			// If we have a validate function use that as it is more specific
+			// and will produce better error messages
+			if (
+				(validationMode === ValidationMode.Validate || validationMode === ValidationMode.Either) &&
+				Is.function(handler.validate)
+			) {
+				return handler.validate(propertyName, data, validationFailures);
+			} else if (
+				(validationMode === ValidationMode.JsonSchema ||
+					validationMode === ValidationMode.Either) &&
+				Is.function(handler.jsonSchema)
+			) {
+				// Otherwise use the JSON schema if there is one
+				const schema = await handler.jsonSchema();
+
+				if (Is.object<JSONSchema7>(schema)) {
+					const validationResult = await JsonSchemaHelper.validate(schema, data);
+					if (Is.arrayValue(validationResult.error)) {
+						validationFailures.push({
+							property: propertyName,
+							reason: "validation.schema.failedValidation",
+							properties: {
+								value: data,
+								schemaErrors: validationResult.error,
+								message: validationResult.error.map(e => e.message).join(", ")
+							}
+						});
+					}
+					return validationResult.result;
+				}
+			}
+		}
+		// Return true by default if no other mechanism for validation is available
+		return true;
+	}
+
+	/**
+	 * Validate a data type.
+	 * @param propertyName The name of the property being validated to use in error messages.
+	 * @param dataType The data type to validate.
 	 * @param data The data to validate.
 	 * @param validationFailures The list of validation failures to add to.
 	 * @param validationMode The validation mode to use, defaults to either.
@@ -26,48 +90,13 @@ export class DataTypeHelper {
 		validationFailures: IValidationFailure[],
 		validationMode?: ValidationMode
 	): Promise<boolean> {
-		if (Is.stringValue(dataType)) {
-			const handler = DataTypeHandlerFactory.getIfExists(dataType);
-
-			if (handler) {
-				validationMode = validationMode ?? ValidationMode.Either;
-
-				// If we have a validate function use that as it is more specific
-				// and will produce better error messages
-				if (
-					(validationMode === ValidationMode.Validate ||
-						validationMode === ValidationMode.Either) &&
-					Is.function(handler.validate)
-				) {
-					return handler.validate(propertyName, data, validationFailures);
-				} else if (
-					(validationMode === ValidationMode.JsonSchema ||
-						validationMode === ValidationMode.Either) &&
-					Is.function(handler.jsonSchema)
-				) {
-					// Otherwise use the JSON schema if there is one
-					const schema = await handler.jsonSchema();
-
-					if (Is.object<JSONSchema7>(schema)) {
-						const validationResult = await JsonSchemaHelper.validate(schema, data);
-						if (Is.arrayValue(validationResult.error)) {
-							validationFailures.push({
-								property: propertyName,
-								reason: "validation.schema.failedValidation",
-								properties: {
-									value: data,
-									schemaErrors: validationResult.error,
-									message: validationResult.error.map(e => e.message).join(", ")
-								}
-							});
-						}
-						return validationResult.result;
-					}
-				}
-			}
-		}
-
-		// Return true by default if no other mechanism for validation is available
-		return true;
+		return DataTypeHelper.validateWithExpandedType(
+			propertyName,
+			dataType,
+			undefined,
+			data,
+			validationFailures,
+			validationMode
+		);
 	}
 }

--- a/packages/data-json-ld/docs/reference/classes/JsonLdHelper.md
+++ b/packages/data-json-ld/docs/reference/classes/JsonLdHelper.md
@@ -16,7 +16,7 @@ Class to help with JSON LD.
 
 ### validate()
 
-> `static` **validate**\<`T`\>(`document`, `validationFailures`, `validationMode?`): `Promise`\<`boolean`\>
+> `static` **validate**\<`T`\>(`document`, `validationFailures`, `validationMode?`, `expand?`): `Promise`\<`boolean`\>
 
 Validate a JSON-LD document.
 
@@ -45,6 +45,12 @@ The list of validation failures to add to.
 `ValidationMode`
 
 The validation mode to use, defaults to either.
+
+##### expand?
+
+`boolean`
+
+Whether the JSON-Ld document has to be expanded.
 
 #### Returns
 

--- a/packages/data-json-ld/src/utils/jsonLdHelper.ts
+++ b/packages/data-json-ld/src/utils/jsonLdHelper.ts
@@ -1,7 +1,8 @@
 // Copyright 2024 IOTA Stiftung.
 // SPDX-License-Identifier: Apache-2.0.
-import { Is, type IValidationFailure } from "@twin.org/core";
+import { ArrayHelper, Is, type IValidationFailure } from "@twin.org/core";
 import { DataTypeHelper, type ValidationMode } from "@twin.org/data-core";
+import { JsonLdProcessor } from "jsonld";
 import type { IJsonLdDocument } from "../models/IJsonLdDocument";
 import type { IJsonLdNodeObject } from "../models/IJsonLdNodeObject";
 
@@ -33,11 +34,13 @@ export class JsonLdHelper {
 			}
 		} else if (Is.object<IJsonLdNodeObject>(document)) {
 			// If the graph is a single node, then use the validate the node schema
-			const dataType = document["@type"];
-			if (Is.stringValue(dataType)) {
-				await DataTypeHelper.validate(
+			const expandedDoc = await JsonLdProcessor.expand(document);
+			const expandedDataType = ArrayHelper.fromObjectOrArray(expandedDoc[0]["@type"]);
+			if (Is.arrayValue(expandedDataType)) {
+				await DataTypeHelper.validateWithExpandedType(
 					"document",
-					dataType,
+					ArrayHelper.fromObjectOrArray(document["@type"])[0],
+					expandedDataType[0],
 					document,
 					validationFailures,
 					validationMode

--- a/packages/data-json-ld/src/utils/jsonLdHelper.ts
+++ b/packages/data-json-ld/src/utils/jsonLdHelper.ts
@@ -15,32 +15,46 @@ export class JsonLdHelper {
 	 * @param document The JSON-LD document to validate.
 	 * @param validationFailures The list of validation failures to add to.
 	 * @param validationMode The validation mode to use, defaults to either.
+	 * @param expand Whether the JSON-Ld document has to be expanded.
 	 * @returns True if the document was valid.
 	 */
 	public static async validate<T extends IJsonLdDocument = IJsonLdDocument>(
 		document: T,
 		validationFailures: IValidationFailure[],
-		validationMode?: ValidationMode
+		validationMode?: ValidationMode,
+		expand?: boolean
 	): Promise<boolean> {
 		if (Is.array<IJsonLdNodeObject>(document)) {
 			// If the document is an array of nodes, validate each node
 			for (const node of document) {
-				await JsonLdHelper.validate(node, validationFailures, validationMode);
+				await JsonLdHelper.validate(node, validationFailures, validationMode, expand);
 			}
 		} else if (Is.array<IJsonLdNodeObject>(document["@graph"])) {
 			// If the graph is an array of nodes, validate each node
 			for (const node of document["@graph"]) {
-				await JsonLdHelper.validate(node, validationFailures, validationMode);
+				await JsonLdHelper.validate(node, validationFailures, validationMode, expand);
 			}
 		} else if (Is.object<IJsonLdNodeObject>(document)) {
-			// If the graph is a single node, then use the validate the node schema
-			const expandedDoc = await JsonLdProcessor.expand(document);
-			const expandedDataType = ArrayHelper.fromObjectOrArray(expandedDoc[0]["@type"]);
-			if (Is.arrayValue(expandedDataType)) {
-				await DataTypeHelper.validateWithExpandedType(
+			const dataType = ArrayHelper.fromObjectOrArray(document["@type"])[0];
+			// If JSON-LD has to be expanded the data type will be the expanded one
+			if (expand) {
+				// If the graph is a single node, then use the validate the node schema
+				const expandedDoc = await JsonLdProcessor.expand(document);
+				const expandedDataType = ArrayHelper.fromObjectOrArray(expandedDoc[0]["@type"]);
+				if (Is.arrayValue(expandedDataType)) {
+					await DataTypeHelper.validateWithExpandedType(
+						"document",
+						dataType,
+						expandedDataType[0],
+						document,
+						validationFailures,
+						validationMode
+					);
+				}
+			} else if (Is.stringValue(dataType)) {
+				await DataTypeHelper.validate(
 					"document",
-					ArrayHelper.fromObjectOrArray(document["@type"])[0],
-					expandedDataType[0],
+					dataType,
 					document,
 					validationFailures,
 					validationMode


### PR DESCRIPTION
The rationale of this PR is that we need to use the expanded LD type when performing validation. The gain is twofold:

* We are unambiguous when referring to types using their Fully Qualified Name
* We apply aliases over `@type` typically `@type` will be aliased into `type` and through this patch we overcome at the same time that issue.

Note: The current patch keeps the old validate function version in order not to break other repos that might be having the previous assumptions. Also adds an extra parameter to JsonHelper.validate to avoid breaking other repos. 

NB: Future-wise I do think we should only have one version, the one that only uses Fully Qualified Names, i.e expands. 